### PR TITLE
Ajoute Le site national de l'adresse Terms of Service

### DIFF
--- a/declarations/Le site national de l'adresse.json
+++ b/declarations/Le site national de l'adresse.json
@@ -1,0 +1,11 @@
+{
+  "name": "Le site national de l'adresse",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://adresse.data.gouv.fr/cgu",
+      "select": [
+        "main"
+      ]
+    }
+  }
+}


### PR DESCRIPTION

Hello

Cette pull request est une migration d'une contribution [anonyme](https://github.com/OpenTermsArchive/contrib-declarations/pull/1513) pour ajouter le document du type `Terms of Service` du service `Le site national de l'adresse` dans cette collection.

🚀 