### PR TITLE
Ajoute Agence Nationale des Titres Sécurisés Terms of Service

### DIFF
--- a/declarations/Agence Nationale des Titres Securises.json
+++ b/declarations/Agence Nationale des Titres Securises.json
@@ -1,0 +1,11 @@
+{
+  "name": "Agence Nationale des Titres Sécurisés",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://passeport.ants.gouv.fr/conditions-generales-d-utilisation-cgu",
+      "select": [
+        "main"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Hello

Cette pull request est une migration d'une contribution [anonyme](https://github.com/OpenTermsArchive/contrib-declarations/pull/1530) pour ajouter le document du type `Terms of Service` du service `Agence Nationale des Titres Sécurisés` dans cette collection.

🚗 