### PR TITLE
Supprime le blink sur Démarches Simplifiées - Terms of Service

### DIFF
--- a/declarations/Demarches simplifiees.json
+++ b/declarations/Demarches simplifiees.json
@@ -9,7 +9,8 @@
       "remove": [
         ".leading-snug",
         ".leading-tight",
-        "a.group"
+        "a.group",
+        "p:has(time)"
       ]
     }
   }


### PR DESCRIPTION
Permet de supprimer le [blink](https://github.com/iroco-co/france-public-versions/commits/main/Demarches%20simplifiees) qui enregistre chaque jour un nouvelle version parceque le document contient la phrase `Dernière mise à jour il y a <number_of_days> jours` qui est mise à jour automatiquement.