### PR TITLE
Mets à jour la configuration de All Contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,6 +1,6 @@
 {
-  "projectName": "demo-declarations",
-  "projectOwner": "OpenTermsArchive",
+  "projectName": "france-public-declarations",
+  "projectOwner": "Iroco",
   "files": [
     ".all-contributors.md"
   ],


### PR DESCRIPTION
Cette modification permettra d'afficher les contributeurs de cette collection sur la futur page dédiée du site d'Open Terms Archive.