### PR TITLE
Mets à jour le lien vers Open Collective

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -7,6 +7,7 @@ dataset: https://github.com/iroco-co/france-public-versions/releases
 declarations: https://github.com/iroco-co/france-public-declarations
 versions: https://github.com/iroco-co/france-public-versions
 snapshots: https://github.com/iroco-co/france-public-snapshots
+donations: https://opencollective.com/opentermsarchive/projects/france-public-services
 logo: https://opentermsarchive.org/images/collections/france-public-services.png
 languages: [fr]
 jurisdictions: [EU]


### PR DESCRIPTION
Ce changement permettra de faire un lien depuis la page de la collection fédérée sur le site web d'Open Terms Archive vers la page Open Collective dédiée à cette collection.