### PR TITLE
Bump engine to next major ^6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "dataset:schedule": "npm run dataset -- --publish --remove-local-copy --schedule"
   },
   "dependencies": {
-    "@opentermsarchive/engine": "~5.0.0"
+    "@opentermsarchive/engine": "~6.0.0"
   }
 }


### PR DESCRIPTION
Update engine to next Major release 6.0.0 instead of migrating from 5.0.0 to 7.0.0.